### PR TITLE
feat(docs): implement GitHub Pages with automated documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,20 @@
+title: SAUCE Agua Gateway Service
+description: Documentación del servicio Gateway de SAUCE Agua
+theme: jekyll-theme-cayman
+
+# Configuración importante para Jekyll
+defaults:
+  -
+    scope:
+      path: "" # aplica a todos los archivos
+    values:
+      layout: default
+
+# Especificar que los archivos .md deben ser procesados
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+
+# Configurar la página principal
+index_page: index.md 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+# SAUCE Agua Gateway Service
+
+Bienvenido a la documentación del servicio Gateway de SAUCE Agua.
+
+## Descripción
+
+Este es el servidor de gateway de servicios (Gateway Server) para la arquitectura de microservicios de SAUCE Agua.
+
+## Navegación
+
+- [Documentación Detallada del Proyecto](project-documentation.html) - Documentación generada automáticamente con:
+  - Estado actual de los Milestones
+  - Lista de Issues activos y cerrados
+  - Historial de cambios
+
+## Estado del Proyecto
+
+El estado actual del proyecto y sus avances se pueden consultar en la [Documentación Detallada](project-documentation.html).
+
+## Enlaces Útiles
+
+- [Repositorio en GitHub](https://github.com/SAUCE-services/SAUCE.agua.gateway-service)
+- [Wiki del Proyecto](https://github.com/SAUCE-services/SAUCE.agua.gateway-service/wiki) 

--- a/scripts/fetch_github_data.py
+++ b/scripts/fetch_github_data.py
@@ -1,0 +1,46 @@
+from github import Github
+import json
+import os
+
+def fetch_github_data():
+    # Inicializar cliente de GitHub
+    g = Github(os.environ['GITHUB_TOKEN'])
+    
+    # Obtener el repositorio actual
+    repo = g.get_repo(os.environ['GITHUB_REPOSITORY'])
+    
+    # Obtener issues
+    issues_data = []
+    for issue in repo.get_issues(state='all'):
+        issues_data.append({
+            'number': issue.number,
+            'title': issue.title,
+            'state': issue.state,
+            'created_at': issue.created_at.isoformat(),
+            'closed_at': issue.closed_at.isoformat() if issue.closed_at else None,
+            'labels': [label.name for label in issue.labels],
+            'milestone': issue.milestone.title if issue.milestone else None,
+            'body': issue.body or ''
+        })
+    
+    # Obtener milestones
+    milestones_data = []
+    for milestone in repo.get_milestones(state='all'):
+        milestone_data = {
+            'title': milestone.title,
+            'description': milestone.description or '',
+            'state': milestone.state,
+            'created_at': milestone.created_at.isoformat() if milestone.created_at else None,
+            'due_on': milestone.due_on.isoformat() if milestone.due_on else None
+        }
+        milestones_data.append(milestone_data)
+    
+    # Guardar datos
+    os.makedirs('data', exist_ok=True)
+    with open('data/issues.json', 'w') as f:
+        json.dump(issues_data, f, indent=2)
+    with open('data/milestones.json', 'w') as f:
+        json.dump(milestones_data, f, indent=2)
+
+if __name__ == '__main__':
+    fetch_github_data() 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,0 +1,87 @@
+import json
+from datetime import datetime
+from jinja2 import Template
+import os
+
+def load_data():
+    with open('data/issues.json', 'r') as f:
+        issues = json.load(f)
+    with open('data/milestones.json', 'r') as f:
+        milestones = json.load(f)
+    return issues, milestones
+
+def generate_docs():
+    issues, milestones = load_data()
+    
+    # Template para la documentación
+    template_str = """---
+layout: default
+title: Documentación Detallada
+---
+
+# Documentación Detallada del Proyecto
+
+_Última actualización: {{ current_date }}_
+
+## Resumen de Milestones
+
+| Milestone | Estado | Fecha Límite |
+|-----------|--------|--------------|
+{% for milestone in milestones %}
+| {{ milestone.title }} | {{ milestone.state }} | {{ milestone.due_on if milestone.due_on else 'No definida' }} |
+{% endfor %}
+
+## Detalles de Milestones
+
+{% for milestone in milestones %}
+### {{ milestone.title }}
+**Estado:** {{ milestone.state }}
+**Descripción:** {{ milestone.description }}
+{% if milestone.due_on %}**Fecha límite:** {{ milestone.due_on }}{% endif %}
+
+---
+{% endfor %}
+
+## Issues Activos
+
+{% for issue in issues if issue.state == 'open' %}
+### #{{ issue.number }}: {{ issue.title }}
+**Estado:** {{ issue.state }}
+**Creado:** {{ issue.created_at }}
+{% if issue.milestone %}**Milestone:** {{ issue.milestone }}{% endif %}
+{% if issue.labels %}**Labels:** {{ issue.labels|join(', ') }}{% endif %}
+
+{{ issue.body }}
+
+---
+{% endfor %}
+
+## Issues Cerrados
+
+{% for issue in issues if issue.state == 'closed' %}
+### #{{ issue.number }}: {{ issue.title }}
+**Estado:** {{ issue.state }}
+**Creado:** {{ issue.created_at }}
+**Cerrado:** {{ issue.closed_at }}
+{% if issue.milestone %}**Milestone:** {{ issue.milestone }}{% endif %}
+{% if issue.labels %}**Labels:** {{ issue.labels|join(', ') }}{% endif %}
+
+{{ issue.body }}
+
+---
+{% endfor %}
+"""
+    
+    template = Template(template_str)
+    doc_content = template.render(
+        current_date=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        issues=issues,
+        milestones=milestones
+    )
+    
+    # Guardar la documentación
+    with open('docs/project-documentation.md', 'w') as f:
+        f.write(doc_content)
+
+if __name__ == '__main__':
+    generate_docs() 


### PR DESCRIPTION
* Add Jekyll configuration with Cayman theme
* Create initial documentation structure in /docs
* Implement Python scripts for automated documentation:
  - fetch_github_data.py for repository data collection
  - generate_docs.py for markdown generation
* Set up basic documentation pages:
  - Main index page
  - Project documentation template
* Configure documentation generation workflow

Documentation structure includes:
- Milestone tracking
- Issue status
- Project overview
- Automated updates

Closes #8